### PR TITLE
Update hwcloud.go

### DIFF
--- a/modules/storage/hwcloud.go
+++ b/modules/storage/hwcloud.go
@@ -16,7 +16,7 @@ import (
 )
 
 const multipart_chunk_size int64 = 20000000
-const default_expire int = 1800
+const default_expire int = 7200
 
 type MultipartPartID struct {
 	Etag  string `json:"etag"`


### PR DESCRIPTION
修改BATCH API文件上传url有效时间为2小时, 后续需要根据文件大小判断有效时间。
