### PR TITLE
add pre-receive hook

### DIFF
--- a/modules/repository/hooks.go
+++ b/modules/repository/hooks.go
@@ -74,6 +74,39 @@ done
 `, setting.ScriptType),
 	}
 
+	if setting.CommanMaxFileSize > 0 {
+		hookTpls[0] += fmt.Sprintf(`
+max_size=%d
+
+while read oldrev newrev _; do
+  if [[ "$oldrev" == "0000000000000000000000000000000000000000" ]]; then
+    files=$(git ls-tree --name-only ${newrev})
+    for file in $files; do
+      size=$(git cat-file -s ${newrev}:${file})
+      if [[ ${size} -gt ${max_size} ]]; then
+		    echo "The size of each file should be within $((max_size / 1048576))MB."
+		    exit 1
+	    fi
+	  done
+  else
+    changes=$(git rev-list ${oldrev}..${newrev})
+
+    for commit in ${changes}; do
+      files=$(git diff-tree --no-commit-id --name-only -r ${commit})
+
+      for file in $files; do
+        size=$(git cat-file -s ${commit}:${file})
+        if [[ ${size} -gt ${max_size} ]]; then
+          echo "The size of each file should be within $((max_size / 1048576))MB."
+          exit 1
+        fi
+      done
+    done
+  fi
+done
+`, setting.CommanMaxFileSize)
+	}
+
 	giteaHookTpls = []string{
 		// for pre-receive
 		fmt.Sprintf(`#!/usr/bin/env %s

--- a/modules/setting/server.go
+++ b/modules/setting/server.go
@@ -101,6 +101,7 @@ var (
 	PerWritePerKbTimeout       = 10 * time.Second
 	StaticURLPrefix            string
 	AbsoluteAssetURL           string
+	CommanMaxFileSize          int64 // `ini:"COMMON_MAX_FILE_SIZE"`
 
 	ManifestData string
 )
@@ -259,6 +260,7 @@ func loadServerFrom(rootCfg ConfigProvider) {
 	StartupTimeout = sec.Key("STARTUP_TIMEOUT").MustDuration(0 * time.Second)
 	PerWriteTimeout = sec.Key("PER_WRITE_TIMEOUT").MustDuration(PerWriteTimeout)
 	PerWritePerKbTimeout = sec.Key("PER_WRITE_PER_KB_TIMEOUT").MustDuration(PerWritePerKbTimeout)
+	CommanMaxFileSize = sec.Key("COMMON_MAX_FILE_SIZE").MustInt64()
 
 	defaultAppURL := string(Protocol) + "://" + Domain + ":" + HTTPPort
 	AppURL = sec.Key("ROOT_URL").MustString(defaultAppURL)


### PR DESCRIPTION
增加git钩子pre-receive，普通文件上传限制为100M以内，可通过配置app.ini [server] COMMON_MAX_FILE_SIZE 参数调整，默认不作限制