### PR TITLE
add remote addr to webhook push event payload

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -474,6 +474,9 @@ func pushOptions() map[string]string {
 			}
 		}
 	}
+
+	opts["ME"] = os.Getenv("ME")
+
 	return opts
 }
 

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -475,7 +475,8 @@ func pushOptions() map[string]string {
 		}
 	}
 
-	opts["ME"] = os.Getenv("ME")
+	k := repo_module.EnvRemoteAddr
+	opts[k] = os.Getenv(k)
 
 	return opts
 }

--- a/modules/repository/env.go
+++ b/modules/repository/env.go
@@ -28,6 +28,7 @@ const (
 	EnvIsInternal   = "GITEA_INTERNAL_PUSH"
 	EnvAppURL       = "GITEA_ROOT_URL"
 	EnvActionPerm   = "GITEA_ACTION_PERM"
+	EnvRemoteAddr   = "GITEA_REMOTE_ADDR"
 )
 
 // InternalPushingEnvironment returns an os environment to switch off hooks on push

--- a/modules/repository/push.go
+++ b/modules/repository/push.go
@@ -16,6 +16,7 @@ type PushUpdateOptions struct {
 	RefFullName  git.RefName // branch, tag or other name to push
 	OldCommitID  string
 	NewCommitID  string
+	RemoteAddr   string
 }
 
 // IsNewRef return true if it's a first-time push to a branch, tag or etc.

--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -274,6 +274,7 @@ type PushPayload struct {
 	Before       string           `json:"before"`
 	After        string           `json:"after"`
 	CompareURL   string           `json:"compare_url"`
+	RemoteAddr   string           `json:"remote_addr"`
 	Commits      []*PayloadCommit `json:"commits"`
 	TotalCommits int              `json:"total_commits"`
 	HeadCommit   *PayloadCommit   `json:"head_commit"`

--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -32,6 +32,7 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 
 	ownerName := ctx.Params(":owner")
 	repoName := ctx.Params(":repo")
+	remoteAddr := opts.GitPushOptions["ME"]
 
 	// defer getting the repository at this point - as we should only retrieve it if we're going to call update
 	var repo *repo_model.Repository
@@ -64,6 +65,7 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 				PusherName:   opts.UserName,
 				RepoUserName: ownerName,
 				RepoName:     repoName,
+				RemoteAddr:   remoteAddr,
 			}
 			updates = append(updates, option)
 			if repo.IsEmpty && (refFullName.BranchName() == "master" || refFullName.BranchName() == "main") {

--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -32,7 +32,7 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 
 	ownerName := ctx.Params(":owner")
 	repoName := ctx.Params(":repo")
-	remoteAddr := opts.GitPushOptions["ME"]
+	remoteAddr, _ := opts.GitPushOptions[repo_module.EnvRemoteAddr]
 
 	// defer getting the repository at this point - as we should only retrieve it if we're going to call update
 	var repo *repo_model.Repository

--- a/routers/web/repo/githttp.go
+++ b/routers/web/repo/githttp.go
@@ -180,6 +180,7 @@ func httpBase(ctx *context.Context) *serviceHandler {
 			repo_module.EnvPusherName + "=" + ctx.Doer.Name,
 			repo_module.EnvPusherID + fmt.Sprintf("=%d", ctx.Doer.ID),
 			repo_module.EnvAppURL + "=" + setting.AppURL,
+			"ME" + "=" + ctx.RemoteAddr(),
 		}
 
 		if repoExist {

--- a/routers/web/repo/githttp.go
+++ b/routers/web/repo/githttp.go
@@ -180,7 +180,7 @@ func httpBase(ctx *context.Context) *serviceHandler {
 			repo_module.EnvPusherName + "=" + ctx.Doer.Name,
 			repo_module.EnvPusherID + fmt.Sprintf("=%d", ctx.Doer.ID),
 			repo_module.EnvAppURL + "=" + setting.AppURL,
-			"ME" + "=" + ctx.RemoteAddr(),
+			repo_module.EnvRemoteAddr + "=" + ctx.RemoteAddr(),
 		}
 
 		if repoExist {

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -125,6 +125,7 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 						RefFullName: git.RefNameFromTag(tagName),
 						OldCommitID: opts.OldCommitID,
 						NewCommitID: git.EmptySHA,
+						RemoteAddr:  opts.RemoteAddr,
 					}, repo_module.NewPushCommits())
 
 				delTags = append(delTags, tagName)
@@ -145,6 +146,7 @@ func pushUpdates(optsList []*repo_module.PushUpdateOptions) error {
 						RefFullName: opts.RefFullName,
 						OldCommitID: git.EmptySHA,
 						NewCommitID: opts.NewCommitID,
+						RemoteAddr:  opts.RemoteAddr,
 					}, commits)
 
 				addTags = append(addTags, tagName)

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -604,6 +604,7 @@ func (m *webhookNotifier) PushCommits(ctx context.Context, pusher *user_model.Us
 		Repo:         convert.ToRepo(ctx, repo, access_model.Permission{AccessMode: perm.AccessModeOwner}),
 		Pusher:       apiPusher,
 		Sender:       apiPusher,
+		RemoteAddr:   opts.RemoteAddr,
 	}); err != nil {
 		log.Error("PrepareWebhooks: %v", err)
 	}


### PR DESCRIPTION
处理流程是：

1. 将remote addr 设置到环境变量
    1.1 通过api或网页提交的commit
          services/repository/files/temp_repo.go
    1.2 通过git提交的commit
          routers/web/repo/githttp.go

2. 在post received hook 的子命令中能自动获取上一步设置的环境变量（大概原因可能是子进程继承父进程的环境变量），并调用internal api，在api的参数中设置remote addr：
    cmd/hook.go

3. 在post received hook 的internal api中获取remote addr，并设置到消息队里的任务中：
    routers/private/hook_post_receive.go
    modules/repository/push.go

4. 在消息队列的handler中获取remote addr，并发布到push event payload中：
    services/repository/push.go
    services/webhook/notifier.go
    modules/structs/hook.go
    